### PR TITLE
Fix flipbook sharpness: set canvas to 1700x2200

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,8 +111,8 @@
       return;
     }
 
-    const flipbookWidth = 800;
-    const flipbookHeight = 1000;
+    const flipbookWidth = 1700;
+    const flipbookHeight = 2200;
 
     const scale = Math.min(
       window.innerWidth / flipbookWidth,


### PR DESCRIPTION
## Summary

Sets the PageFlip canvas dimensions to 1700×2200 to match the hi-res page images.

The previous 800×1000 canvas caused source images to be downsampled before display, negating any benefit from the 200 DPI export. With the canvas matching the image dimensions, the CSS scale shrinks the canvas to fit the screen — preserving full resolution on all displays including Retina.

## Test plan
- [ ] Merge and deploy
- [ ] Flipbook pages appear sharper compared to before
- [ ] All three catalog years load and flip correctly