### PR TITLE
Force two-page spread by disabling portrait mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
         useMouseEvents: true,
         autoSize: false,
         clickEventForward: true,
-        usePortrait: true,
+        usePortrait: false,
       });
 
       pageFlip.loadFromImages(pages);


### PR DESCRIPTION
## Summary

Sets `usePortrait: false` in the PageFlip config to permanently enforce the open-book two-page layout.

`usePortrait: true` allows PageFlip to override the explicit container width and revert to single-page mode based on its own internal viewport calculations. Disabling it removes that fallback entirely.

## Test plan
- [ ] Merge and deploy
- [ ] Flipbook shows two pages side by side