### PR TITLE
Fix flipbook click zones

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,8 +24,9 @@
       position: absolute;
       top: 0;
       left: 0;
+      right: 0;
+      bottom: 60px;
       background: #ffffff;
-      transform-origin: top left;
     }
 
     #controls {
@@ -107,33 +108,16 @@
       return;
     }
 
-    const flipbookWidth = 1275;
-    const flipbookHeight = 1650;
-
-    flipbookElement.style.width = `${flipbookWidth * 2}px`;
-    flipbookElement.style.height = `${flipbookHeight}px`;
-
-    const scale = Math.min(
-      window.innerWidth / (flipbookWidth * 2),
-      (window.innerHeight - 60) / flipbookHeight
-    );
-
-    flipbookElement.style.transform = `scale(${scale})`;
-
     if (typeof St !== 'undefined' && St.PageFlip) {
       const pageFlip = new St.PageFlip(flipbookElement, {
-        width: flipbookWidth,
-        height: flipbookHeight,
-        size: 'fixed',
-        minWidth: 315,
-        minHeight: 400,
-        maxWidth: 2000,
-        maxHeight: 3000,
+        width: 1275,
+        height: 1650,
+        size: 'stretch',
         showCover: true,
         flippingTime: 700,
         mobileScrollSupport: true,
         useMouseEvents: true,
-        autoSize: false,
+        autoSize: true,
         clickEventForward: true,
         usePortrait: false,
       });


### PR DESCRIPTION
## Summary

Fixes cover page not flipping and pages only flipping backward.

Root cause: `transform: scale()` was applied to the container before PageFlip initialized. PageFlip measured click positions in visual space (after transform) but compared them to the layout dimensions (before transform). The left/right split point was at DOM x=1275px but visually only ~650px from the left — so nearly every click registered as backward. Only a ~24px sliver on the far right triggered forward.

Fix: remove the manual `width`/`height`/`transform` setup entirely and switch to `size: 'stretch'`. PageFlip now fills the container naturally so click zones match exactly what the user sees.

## Test plan
- [ ] Cover page click flips the book open
- [ ] Clicking right half of spread goes forward
- [ ] Clicking left half goes backward
- [ ] Slider still works